### PR TITLE
Wrap external errors in Error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,20 +5,20 @@ use rustc_serialize::json;
 #[derive(Debug)]
 pub enum Error {
     Format,
-    Base64,
-    Decode,
-    Encode,
-    Json,
-    Parse,
-    Utf8,
+    Base64(FromBase64Error),
+    Decode(json::DecoderError),
+    Encode(json::EncoderError),
+    Json(json::ErrorCode),
+    Parse(json::ParserError),
+    Utf8(FromUtf8Error),
 }
 
 macro_rules! error_wrap {
     ($f: ty, $e: expr) => {
-    impl From<$f> for Error {
-        fn from(_: $f) -> Error { $e }
+        impl From<$f> for Error {
+            fn from(f: $f) -> Error { $e(f) }
+        }
     }
-}
 }
 
 error_wrap!(FromBase64Error, Error::Base64);


### PR DESCRIPTION
The original code made debugging errors hard as the original error was lost. Now we wrap the external errors in the `Error` type so this information isn't lost.