### PR TITLE
Compatibility fix for rust beta and rust nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub struct Token<H, C>
     pub claims: C,
 }
 
-pub trait Component {
+pub trait Component: Sized {
     fn from_base64(raw: &str) -> Result<Self, Error>;
     fn to_base64(&self) -> Result<String, Error>;
 }


### PR DESCRIPTION
There is a compiler warning in rust stable (1.5.0):
```bash
src/lib.rs:36:5: 36:54 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:36     fn from_base64(raw: &str) -> Result<Self, Error>;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:36:5: 36:54 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:36:5: 36:54 note: `Self` does not have a constant size known at compile-time
src/lib.rs:36:5: 36:54 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:36     fn from_base64(raw: &str) -> Result<Self, Error>;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:36:5: 36:54 note: required by `core::result::Result`
```

In beta and nightly channels this is a hard error.

I've added the `Sized` trait to `Component` which resolves the error. 
This change doesn't break any existing tests or examples in this repository.

Thanks for the great library!