### PR TITLE
Removed an unused import in `header.rs`

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1,5 +1,4 @@
 use std::default::Default;
-use error::Error;
 
 #[derive(Debug, PartialEq, RustcDecodable, RustcEncodable)]
 pub struct Header {


### PR DESCRIPTION
Removed an unused `error::Error` import in the headers file.