### PR TITLE
Add sign_rsa() temporarily until crypto crate supports RSA encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+examples/keys

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ license = "MIT"
 [dependencies]
 rust-crypto = "0.2"
 rustc-serialize = "0.3"
+openssl = "0.8"

--- a/examples/rs256.rs
+++ b/examples/rs256.rs
@@ -1,0 +1,47 @@
+extern crate crypto;
+extern crate jwt;
+
+use std::default::Default;
+use jwt::{
+    Header,
+    Registered,
+    Token,
+};
+use std::fs::File;
+use std::io::Read;
+
+fn new_token(user_id: &str) -> Option<String> {
+
+	/* TODO: Run these commands:
+			 $ mkdir -p examples/keys
+			 $ openssl genrsa -out examples/keys/key.rsa 2048
+			 $ openssl rsa -in examples/keys/key.rsa -pubout > examples/keys/key.rsa.pub
+	*/
+	match File::open("keys/key.rsa") {
+		Ok(mut f) => {
+			let mut s = String::new();
+			f.read_to_string(&mut s).unwrap();
+			let header = Header{
+				typ: Some(jwt::header::HeaderType::JWT),
+				kid: None,
+				alg: jwt::header::Algorithm::RS256,
+			};
+		    let claims = Registered {
+		        iss: Some("mikkyang.com".into()),
+		        sub: Some(user_id.into()),
+		        ..Default::default()
+		    };
+		    let token = Token::new(header, claims);
+		    Some(token.sign_rsa(s.as_bytes()).unwrap())
+		},
+		Err(e) => {
+			println!("Error: {}", e);
+			None
+		}
+	}
+}
+
+fn main() {
+    let token = new_token("Michael Yang").unwrap();
+	println!("Token: {}", token);
+}

--- a/src/crypt.rs
+++ b/src/crypt.rs
@@ -1,3 +1,5 @@
+extern crate openssl;
+
 use crypto::digest::Digest;
 use crypto::hmac::Hmac;
 use crypto::mac::{
@@ -8,6 +10,8 @@ use rustc_serialize::base64::{
     FromBase64,
     ToBase64,
 };
+use self::openssl::crypto::rsa;
+use self::openssl::crypto::hash;
 use BASE_CONFIG;
 
 pub fn sign<D: Digest>(data: &str, key: &[u8], digest: D) -> String {
@@ -17,6 +21,11 @@ pub fn sign<D: Digest>(data: &str, key: &[u8], digest: D) -> String {
     let mac = hmac.result();
     let code = mac.code();
     (*code).to_base64(BASE_CONFIG)
+}
+
+pub fn sign_rsa(data: &str, key: &[u8]) -> String {
+	let private_key = rsa::RSA::private_key_from_pem(key).unwrap();
+	(private_key.sign(hash::Type::SHA256, data.as_bytes()).unwrap()).to_base64(BASE_CONFIG)
 }
 
 pub fn verify<D: Digest>(target: &str, data: &str, key: &[u8], digest: D) -> bool {

--- a/src/crypt.rs
+++ b/src/crypt.rs
@@ -28,7 +28,11 @@ pub fn sign_rsa(data: &str, key: &[u8]) -> String {
 	let private_key = rsa::RSA::private_key_from_pem(key).unwrap();
 	let mut hasher = Sha256::new();
 	hasher.input_str(data);
-	(private_key.sign(hash::Type::SHA256, hasher.result_str().as_bytes()).unwrap()).to_base64(BASE_CONFIG)
+	let data_bytes = hasher.output_bytes();
+	let mut data = vec![0u8; data_bytes];
+	let mut data = &mut data[..];
+	hasher.result(&mut data);
+	(private_key.sign(hash::Type::SHA256, data).unwrap()).to_base64(BASE_CONFIG)
 }
 
 pub fn verify<D: Digest>(target: &str, data: &str, key: &[u8], digest: D) -> bool {

--- a/src/crypt.rs
+++ b/src/crypt.rs
@@ -6,6 +6,7 @@ use crypto::mac::{
     Mac,
     MacResult,
 };
+use crypto::sha2::Sha256;
 use rustc_serialize::base64::{
     FromBase64,
     ToBase64,
@@ -25,7 +26,9 @@ pub fn sign<D: Digest>(data: &str, key: &[u8], digest: D) -> String {
 
 pub fn sign_rsa(data: &str, key: &[u8]) -> String {
 	let private_key = rsa::RSA::private_key_from_pem(key).unwrap();
-	(private_key.sign(hash::Type::SHA256, data.as_bytes()).unwrap()).to_base64(BASE_CONFIG)
+	let mut hasher = Sha256::new();
+	hasher.input_str(data);
+	(private_key.sign(hash::Type::SHA256, hasher.result_str().as_bytes()).unwrap()).to_base64(BASE_CONFIG)
 }
 
 pub fn verify<D: Digest>(target: &str, data: &str, key: &[u8], digest: D) -> bool {

--- a/src/crypt.rs
+++ b/src/crypt.rs
@@ -10,6 +10,9 @@ use crypto::sha2::Sha256;
 use rustc_serialize::base64::{
     FromBase64,
     ToBase64,
+	Config,
+	CharacterSet,
+	Newline,
 };
 use self::openssl::crypto::rsa;
 use self::openssl::crypto::hash;
@@ -32,7 +35,13 @@ pub fn sign_rsa(data: &str, key: &[u8]) -> String {
 	let mut data = vec![0u8; data_bytes];
 	let mut data = &mut data[..];
 	hasher.result(&mut data);
-	(private_key.sign(hash::Type::SHA256, data).unwrap()).to_base64(BASE_CONFIG)
+	// (private_key.sign(hash::Type::SHA256, data).unwrap()).to_base64(BASE_CONFIG)
+	(private_key.sign(hash::Type::SHA256, data).unwrap()).to_base64(Config{
+		char_set:		CharacterSet::UrlSafe,
+		newline: 		Newline::LF,
+		pad:			true,
+		line_length:	None,
+	})
 }
 
 pub fn verify<D: Digest>(target: &str, data: &str, key: &[u8], digest: D) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,16 @@ impl<H, C> Token<H, C>
         let sig = crypt::sign(&*data, key, digest);
         Ok(format!("{}.{}", data, sig))
     }
+
+	/// Generate the signed token from an rsa key.
+    pub fn sign_rsa(&self, key: &[u8]) -> Result<String, Error> {
+        let header = try!(Component::to_base64(&self.header));
+        let claims = try!(self.claims.to_base64());
+        let data = format!("{}.{}", header, claims);
+
+		let sig = crypt::sign_rsa(&*data, key);
+        Ok(format!("{}.{}", data, sig))
+    }
 }
 
 impl<H, C> PartialEq for Token<H, C>


### PR DESCRIPTION
I needed to sign a JWT with the RS256 method, to authenticate for the default App Engine service account with Google for the App Engine Flexible Environment custom runtime, running Archlinux/Rust nightly.

So, I added openssl and a function to sign with RSA. You might not like it, but I thought I'd share my changes anyway. Feel free to throw it out or modify it to your liking.
