### PR TITLE
Port to RustCrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ keywords = ["JWT", "token", "web"]
 license = "MIT"
 
 [dependencies]
-rust-crypto = "0.2"
+crypto-mac = "0.7.0"
+digest = "0.8.1"
+hmac = "0.7.1"
+sha2 = "0.8.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/examples/custom_claims.rs
+++ b/examples/custom_claims.rs
@@ -1,11 +1,12 @@
-extern crate crypto;
 extern crate jwt;
 #[macro_use]
 extern crate serde_derive;
+extern crate sha2;
 
 use std::default::Default;
-use crypto::sha2::Sha256;
 use jwt::{Header, Token};
+use sha2::Digest;
+use sha2::Sha256;
 
 #[derive(Default, Deserialize, Serialize)]
 struct Custom {

--- a/examples/hs256.rs
+++ b/examples/hs256.rs
@@ -1,9 +1,10 @@
-extern crate crypto;
 extern crate jwt;
+extern crate sha2;
 
-use std::default::Default;
-use crypto::sha2::Sha256;
 use jwt::{Header, Registered, Token};
+use sha2::Digest;
+use sha2::Sha256;
+use std::default::Default;
 
 fn new_token(user_id: &str, password: &str) -> Option<String> {
     // Dummy auth

--- a/src/crypt.rs
+++ b/src/crypt.rs
@@ -1,27 +1,41 @@
-use crypto::digest::Digest;
-use crypto::hmac::Hmac;
-use crypto::mac::{Mac, MacResult};
 use base64;
+use crypto_mac::Mac;
+use digest::generic_array::ArrayLength;
+use digest::*;
+use hmac::Hmac;
 
-
-pub fn sign<D: Digest>(data: &str, key: &[u8], digest: D) -> String {
-    let mut hmac = Hmac::new(digest, key);
+pub fn sign<D>(data: &str, key: &[u8], _digest: D) -> String
+where
+    D: Input + BlockInput + FixedOutput + Reset + Default + Clone,
+    D::BlockSize: ArrayLength<u8>,
+    D::OutputSize: ArrayLength<u8>,
+{
+    // This will panic for bad key sizes. Returning an error
+    // would probably be better, but for now, I want to keep the
+    // API as stable as possible
+    let mut hmac = Hmac::<D>::new_varkey(key).unwrap();
     hmac.input(data.as_bytes());
 
     let mac = hmac.result();
     let code = mac.code();
-    base64::encode_config(code, base64::URL_SAFE_NO_PAD)
+    base64::encode_config(&code, base64::URL_SAFE_NO_PAD)
 }
 
-pub fn verify<D: Digest>(target: &str, data: &str, key: &[u8], digest: D) -> bool {
+pub fn verify<D>(target: &str, data: &str, key: &[u8], _digest: D) -> bool
+where
+    D: Input + BlockInput + FixedOutput + Reset + Default + Clone,
+    D::BlockSize: ArrayLength<u8>,
+    D::OutputSize: ArrayLength<u8>,
+{
     let target_bytes = match base64::decode_config(target, base64::URL_SAFE_NO_PAD) {
         Ok(x) => x,
         Err(_) => return false,
     };
-    let target_mac = MacResult::new_from_owned(target_bytes);
 
-    let mut hmac = Hmac::new(digest, key);
+    // This will panic for bad key sizes. Returning an error
+    // would probably be better, but for now, I want to keep the
+    // API as stable as possible
+    let mut hmac = Hmac::<D>::new_varkey(key).unwrap();
     hmac.input(data.as_bytes());
-
-    hmac.result() == target_mac
+    hmac.verify(&target_bytes).is_ok()
 }


### PR DESCRIPTION
According to https://rustsec.org/advisories/RUSTSEC-2016-0005.html,
rust-crypto is unmaintained.

Crates depending on rust-crypto should be ported to other crates. One
recommendation are the crates from https://github.com/RustCrypto.

This port replaces rust-crypto with those crates, while keeping the API
of rust-jwt unchanged as far as it is possible.

Unfortunately, rust-jwt's API contains types from rust-crypto, so
changing the underlying implementations necessarily causes a breaking
change.

However, as can be seen in the examples, existing code only needs to
change the types used, not the actual code.

Before publishing a release containing this commit, the version number
of rust-jwt should be updated to reflect the breaking change.