### PR TITLE
Make new header easier to handle

### DIFF
--- a/examples/custom_claims.rs
+++ b/examples/custom_claims.rs
@@ -4,7 +4,7 @@ extern crate serde_derive;
 extern crate sha2;
 
 use std::default::Default;
-use jwt::{HeaderV2 as Header, Token};
+use jwt::{Header, Token};
 use sha2::Digest;
 use sha2::Sha256;
 

--- a/examples/hs256.rs
+++ b/examples/hs256.rs
@@ -1,7 +1,7 @@
 extern crate jwt;
 extern crate sha2;
 
-use jwt::{HeaderV2 as Header, Registered, Token};
+use jwt::{Header, Registered, Token};
 use sha2::Digest;
 use sha2::Sha256;
 use std::default::Default;

--- a/src/header/legacy.rs
+++ b/src/header/legacy.rs
@@ -35,7 +35,7 @@ impl Default for Header {
 #[cfg(test)]
 mod tests {
     use crate::Component;
-    use crate::header::{Algorithm, Header, HeaderType};
+    use crate::header::legacy::{Algorithm, Header, HeaderType};
 
     #[test]
     fn from_base64() {

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -3,10 +3,8 @@ use crate::algorithm::AlgorithmType;
 #[allow(deprecated)]
 pub mod legacy;
 
-pub use self::legacy::*;
-
 #[derive(Default, Debug, PartialEq, Serialize, Deserialize)]
-pub struct HeaderV2 {
+pub struct Header {
     #[serde(rename="alg")]
     pub algorithm: AlgorithmType,
 
@@ -14,7 +12,7 @@ pub struct HeaderV2 {
     pub key_id: Option<String>,
 
     #[serde(rename="typ", skip_serializing_if = "Option::is_none")]
-    pub type_: Option<HeaderTypeV2>,
+    pub type_: Option<HeaderType>,
 
     #[serde(rename="cty", skip_serializing_if = "Option::is_none")]
     pub content_type: Option<HeaderContentType>,
@@ -22,7 +20,7 @@ pub struct HeaderV2 {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all="UPPERCASE")]
-pub enum HeaderTypeV2 {
+pub enum HeaderType {
     #[serde(rename="JWT")]
     JsonWebToken,
 }
@@ -38,18 +36,18 @@ pub enum HeaderContentType {
 mod tests {
     use crate::Component;
     use crate::algorithm::AlgorithmType;
-    use crate::header::{HeaderV2, HeaderTypeV2};
+    use crate::header::{Header, HeaderType};
 
     #[test]
     fn from_base64() {
         let enc = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
-        let header = HeaderV2::from_base64(enc).unwrap();
+        let header = Header::from_base64(enc).unwrap();
 
-        assert_eq!(header.type_.unwrap(), HeaderTypeV2::JsonWebToken);
+        assert_eq!(header.type_.unwrap(), HeaderType::JsonWebToken);
         assert_eq!(header.algorithm, AlgorithmType::Hs256);
 
         let enc = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFLU0YzZyJ9";
-        let header = HeaderV2::from_base64(enc).unwrap();
+        let header = Header::from_base64(enc).unwrap();
 
         assert_eq!(header.key_id.unwrap(), "1KSF3g".to_string());
         assert_eq!(header.algorithm, AlgorithmType::Rs256);
@@ -57,8 +55,8 @@ mod tests {
 
     #[test]
     fn roundtrip() {
-        let header: HeaderV2 = Default::default();
+        let header: Header = Default::default();
         let enc = Component::to_base64(&header).unwrap();
-        assert_eq!(header, HeaderV2::from_base64(&*enc).unwrap());
+        assert_eq!(header, Header::from_base64(&*enc).unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use digest::*;
 
 pub use crate::error::Error;
 pub use crate::header::Header;
-pub use crate::header::HeaderV2;
 pub use crate::claims::Claims;
 pub use crate::claims::Registered;
 
@@ -154,7 +153,7 @@ mod tests {
     use crate::Token;
     use digest::Digest;
     use crate::algorithm::AlgorithmType::Hs256;
-    use crate::header::HeaderV2;
+    use crate::header::Header;
     use sha2::Sha256;
 
     #[test]
@@ -182,7 +181,7 @@ mod tests {
     #[test]
     pub fn raw_data() {
         let raw = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
-        let token = Token::<HeaderV2, Claims>::parse(raw).unwrap();
+        let token = Token::<Header, Claims>::parse(raw).unwrap();
 
         {
             assert_eq!(token.header.algorithm, Hs256);
@@ -192,7 +191,7 @@ mod tests {
 
     #[test]
     pub fn roundtrip() {
-        let token: Token<HeaderV2, Claims> = Default::default();
+        let token: Token<Header, Claims> = Default::default();
         let key = "secret".as_bytes();
         let raw = token.signed(key, Sha256::new()).unwrap();
         let same = Token::parse(&*raw).unwrap();


### PR DESCRIPTION
Make older users prefix legacy instead and make ergonomics of newer code easier.