### PR TITLE
Update RustCrypto deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["JWT", "token", "web"]
 license = "MIT"
 
 [dependencies]
-base64 = "0.10"
-crypto-mac = "0.7"
-digest = "0.8"
-hmac = "0.7"
-sha2 = "0.8"
+base64 = "0.12"
+crypto-mac = "0.8"
+digest = "0.9"
+hmac = "0.8"
+sha2 = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ extern crate hmac;
 extern crate jwt;
 extern crate sha2;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 use jwt::SignWithKey;
 use sha2::Sha256;
 use std::collections::BTreeMap;
@@ -54,7 +54,7 @@ extern crate hmac;
 extern crate jwt;
 extern crate sha2;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 use jwt::VerifyWithKey;
 use sha2::Sha256;
 use std::collections::BTreeMap;
@@ -82,7 +82,7 @@ extern crate hmac;
 extern crate jwt;
 extern crate sha2;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 use jwt::{AlgorithmType, Header, SignWithKey, Token};
 use sha2::Sha384;
 use std::collections::BTreeMap;
@@ -109,7 +109,7 @@ extern crate hmac;
 extern crate jwt;
 extern crate sha2;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 use jwt::{AlgorithmType, Header, Token, VerifyWithKey};
 use sha2::Sha384;
 use std::collections::BTreeMap;
@@ -141,7 +141,7 @@ extern crate hmac;
 extern crate jwt;
 extern crate sha2;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 use jwt::{Header, SignWithStore, Token, VerifyWithStore};
 use sha2::Sha512;
 use std::collections::BTreeMap;

--- a/examples/custom_claims.rs
+++ b/examples/custom_claims.rs
@@ -25,7 +25,6 @@ fn new_token(user_id: &str, password: &str) -> Result<String, &'static str> {
     let claims = Custom {
         sub: user_id.into(),
         rhino: true,
-        ..Default::default()
     };
     let unsigned_token = Token::new(header, claims);
 

--- a/examples/custom_claims.rs
+++ b/examples/custom_claims.rs
@@ -4,7 +4,7 @@ extern crate jwt;
 extern crate serde_derive;
 extern crate sha2;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 use jwt::{Header, SignWithKey, Token, VerifyWithKey};
 use sha2::Sha256;
 use std::default::Default;

--- a/examples/hs256.rs
+++ b/examples/hs256.rs
@@ -23,7 +23,7 @@ fn new_token(user_id: &str, password: &str) -> Result<String, &'static str> {
 
     let signed_token = claims.sign_with_key(&key).map_err(|_e| "Sign failed")?;
 
-    Ok(signed_token.into())
+    Ok(signed_token)
 }
 
 fn login(token: &str) -> Result<String, &'static str> {

--- a/examples/hs256.rs
+++ b/examples/hs256.rs
@@ -2,7 +2,7 @@ extern crate hmac;
 extern crate jwt;
 extern crate sha2;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 use jwt::{RegisteredClaims, SignWithKey, VerifyWithKey};
 use sha2::Sha256;
 use std::default::Default;

--- a/examples/hs256_legacy.rs
+++ b/examples/hs256_legacy.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 extern crate jwt;
 extern crate sha2;
 

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -7,7 +7,7 @@
 //! extern crate hmac;
 //! extern crate sha2;
 //!
-//! use hmac::{Hmac, Mac};
+//! use hmac::{Hmac, NewMac};
 //! use sha2::Sha256;
 //!
 //! let hs256_key: Hmac<Sha256> = Hmac::new_varkey(b"some-secret").unwrap();

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -59,7 +59,7 @@ mod tests {
     use std::default::Default;
 
     // {"iss":"mikkyang.com","exp":1302319100,"custom_claim":true}
-    const ENCODED_PAYLOAD: &'static str =
+    const ENCODED_PAYLOAD: &str =
         "eyJpc3MiOiJtaWtreWFuZy5jb20iLCJleHAiOjEzMDIzMTkxMDAsImN1c3RvbV9jbGFpbSI6dHJ1ZX0K";
 
     #[test]

--- a/src/header.rs
+++ b/src/header.rs
@@ -46,7 +46,7 @@ impl JoseHeader for Header {
     }
 
     fn key_id(&self) -> Option<&str> {
-        self.key_id.as_ref().map(|s| &**s)
+        self.key_id.as_deref()
     }
 
     fn type_(&self) -> Option<HeaderType> {

--- a/src/legacy/claims.rs
+++ b/src/legacy/claims.rs
@@ -28,7 +28,7 @@ pub struct Registered {
 impl Claims {
     pub fn new(reg: Registered) -> Claims {
         Claims {
-            reg: reg,
+            reg,
             private: BTreeMap::new(),
         }
     }
@@ -41,7 +41,7 @@ mod tests {
     use std::default::Default;
 
     // {"iss":"mikkyang.com","exp":1302319100,"custom_claim":true}
-    const ENCODED_PAYLOAD: &'static str =
+    const ENCODED_PAYLOAD: &str =
         "eyJpc3MiOiJtaWtreWFuZy5jb20iLCJleHAiOjEzMDIzMTkxMDAsImN1c3RvbV9jbGFpbSI6dHJ1ZX0K";
 
     #[test]

--- a/src/legacy/mod.rs
+++ b/src/legacy/mod.rs
@@ -6,7 +6,7 @@ use crate::token::verified::split_components;
 use crate::{FromBase64, ToBase64, SEPARATOR};
 use digest::generic_array::ArrayLength;
 use digest::*;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, NewMac};
 
 pub use crate::legacy::claims::Claims;
 pub use crate::legacy::claims::Registered;
@@ -62,7 +62,7 @@ where
     /// Make sure to check the token's algorithm before applying.
     pub fn verify<D>(&self, key: &[u8], _digest: D) -> bool
     where
-        D: Input
+        D: Update
             + BlockInput
             + FixedOutput
             + Reset
@@ -89,7 +89,7 @@ where
     /// Generate the signed token from a key and a given hashing algorithm.
     pub fn signed<D>(&self, key: &[u8], _digest: D) -> Result<String, Error>
     where
-        D: Input
+        D: Update
             + BlockInput
             + FixedOutput
             + Reset
@@ -130,13 +130,13 @@ where
     note = "This is usually implemented through a blanket impl, but if needed use the ToBase64 and FromBase64 traits"
 )]
 pub trait Component: Sized {
-    fn from_base64<Input: ?Sized + AsRef<[u8]>>(raw: &Input) -> Result<Self, Error>;
+    fn from_base64<Update: ?Sized + AsRef<[u8]>>(raw: &Update) -> Result<Self, Error>;
     fn to_base64(&self) -> Result<String, Error>;
 }
 
 impl<T: ToBase64 + FromBase64> Component for T {
     /// Parse from a string.
-    fn from_base64<Input: ?Sized + AsRef<[u8]>>(raw: &Input) -> Result<T, Error> {
+    fn from_base64<Update: ?Sized + AsRef<[u8]>>(raw: &Update) -> Result<T, Error> {
         FromBase64::from_base64(raw)
     }
 

--- a/src/legacy/mod.rs
+++ b/src/legacy/mod.rs
@@ -35,8 +35,8 @@ where
     pub fn new(header: H, claims: C) -> Token<H, C> {
         Token {
             raw: None,
-            header: header,
-            claims: claims,
+            header,
+            claims,
         }
     }
 
@@ -163,13 +163,13 @@ mod tests {
         {
             assert_eq!(token.header.algorithm, Hs256);
         }
-        assert!(token.verify("secret".as_bytes(), Sha256::new()));
+        assert!(token.verify(b"secret", Sha256::new()));
     }
 
     #[test]
     pub fn roundtrip() {
         let token: Token<Header, Claims> = Default::default();
-        let key = "secret".as_bytes();
+        let key = b"secret";
         let raw = token.signed(key, Sha256::new()).unwrap();
         let same = Token::parse(&*raw).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! extern crate hmac;
 //! extern crate sha2;
 //!
-//! use hmac::{Hmac, Mac};
+//! use hmac::{Hmac, NewMac};
 //! use jwt::SignWithKey;
 //! use sha2::Sha256;
 //! use std::collections::BTreeMap;
@@ -34,7 +34,7 @@
 //! extern crate hmac;
 //! extern crate sha2;
 //!
-//! use hmac::{Hmac, Mac};
+//! use hmac::{Hmac, NewMac};
 //! use jwt::VerifyWithKey;
 //! use sha2::Sha256;
 //! use std::collections::BTreeMap;
@@ -59,7 +59,7 @@
 //! extern crate hmac;
 //! extern crate sha2;
 //!
-//! use hmac::{Hmac, Mac};
+//! use hmac::{Hmac, NewMac};
 //! use jwt::{AlgorithmType, Header, SignWithKey, Token};
 //! use sha2::Sha384;
 //! use std::collections::BTreeMap;
@@ -85,7 +85,7 @@
 //! extern crate hmac;
 //! extern crate sha2;
 //!
-//! use hmac::{Hmac, Mac};
+//! use hmac::{Hmac, NewMac};
 //! use jwt::{AlgorithmType, Header, Token, VerifyWithKey};
 //! use sha2::Sha384;
 //! use std::collections::BTreeMap;
@@ -225,7 +225,7 @@ mod tests {
     use crate::Claims;
     use crate::Token;
     use hmac::Hmac;
-    use hmac::Mac;
+    use hmac::NewMac;
     use sha2::Sha256;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub mod header;
 pub mod legacy;
 pub mod token;
 
-const SEPARATOR: &'static str = ".";
+const SEPARATOR: &str = ".";
 
 /// Representation of a structured JWT. Methods vary based on the signature
 /// type `S`.

--- a/src/token/signed.rs
+++ b/src/token/signed.rs
@@ -144,7 +144,7 @@ mod tests {
     use crate::header::Header;
     use crate::token::signed::{SignWithKey, SignWithStore};
     use crate::Token;
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, NewMac};
     use sha2::{Sha256, Sha512};
     use std::collections::BTreeMap;
 

--- a/src/token/verified.rs
+++ b/src/token/verified.rs
@@ -137,7 +137,7 @@ mod tests {
     use crate::algorithm::VerifyingAlgorithm;
     use crate::error::Error;
     use crate::token::verified::VerifyWithStore;
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, NewMac};
     use sha2::{Sha256, Sha512};
     use std::collections::BTreeMap;
 


### PR DESCRIPTION
First of all,
thanks for this awesome library!

This PR updates updates all outdated dependencies, and fixes the code to comply with all the breaking changes from here: https://www.reddit.com/r/rust/comments/h0em5n/ann_new_rustcrypto_releases_aead_blockcipher/ (100% of the changes are semantic renaming of functions).
Also fixed a few clippy warnings for good measure.