### PR TITLE
Do not panic when a key is missing from a Store

### DIFF
--- a/src/algorithm/store.rs
+++ b/src/algorithm/store.rs
@@ -1,4 +1,6 @@
-use std::ops::Index;
+use std::borrow::Borrow;
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
 
 /// A store of keys that can be retrieved by key id.
 pub trait Store {
@@ -7,13 +9,24 @@ pub trait Store {
     fn get(&self, key_id: &str) -> Option<&Self::Algorithm>;
 }
 
-impl<T, A> Store for T
+impl<K, A> Store for BTreeMap<K, A>
 where
-    for<'a> T: Index<&'a str, Output = A>,
+    K: Borrow<str> + Ord,
 {
     type Algorithm = A;
 
     fn get(&self, key_id: &str) -> Option<&A> {
-        Some(&self[key_id])
+        BTreeMap::get(self, key_id)
+    }
+}
+
+impl<K, A> Store for HashMap<K, A>
+where
+    K: Borrow<str> + Ord + Hash,
+{
+    type Algorithm = A;
+
+    fn get(&self, key_id: &str) -> Option<&A> {
+        HashMap::get(self, key_id)
     }
 }

--- a/src/token/verified.rs
+++ b/src/token/verified.rs
@@ -157,7 +157,7 @@ mod tests {
     use crate::error::Error;
     use crate::token::verified::{VerifyWithKey, VerifyWithStore};
 
-    #[derive(Deserialize)]
+    #[derive(Debug, Deserialize)]
     struct Claims {
         name: String,
     }
@@ -247,13 +247,13 @@ mod tests {
 
     // Header   {"alg":"HS512","kid":"second_key"}
     // Claims   {"name":"Jane Doe"}
-    const JANE_DOE_TOKEN: &'static str = "eyJhbGciOiJIUzUxMiIsImtpZCI6InNlY29uZF9rZXkifQ.eyJuYW1lIjoiSmFuZSBEb2UifQ.t2ON5s8DDb2hefBIWAe0jaEcp-T7b2Wevmj0kKJ8BFxKNQURHpdh4IA-wbmBmqtiCnqTGoRdqK45hhW0AOtz0A";
+    const JANE_DOE_SECOND_KEY_TOKEN: &'static str = "eyJhbGciOiJIUzUxMiIsImtpZCI6InNlY29uZF9rZXkifQ.eyJuYW1lIjoiSmFuZSBEb2UifQ.t2ON5s8DDb2hefBIWAe0jaEcp-T7b2Wevmj0kKJ8BFxKNQURHpdh4IA-wbmBmqtiCnqTGoRdqK45hhW0AOtz0A";
 
     #[test]
     pub fn verify_claims_with_b_tree_map() -> Result<(), Error> {
         let key_store: BTreeMap<_, _> = create_test_data()?;
 
-        let claims: Claims = JANE_DOE_TOKEN.verify_with_store(&key_store)?;
+        let claims: Claims = JANE_DOE_SECOND_KEY_TOKEN.verify_with_store(&key_store)?;
 
         assert_eq!(claims.name, "Jane Doe");
         Ok(())
@@ -263,9 +263,27 @@ mod tests {
     pub fn verify_claims_with_hash_map() -> Result<(), Error> {
         let key_store: HashMap<_, _> = create_test_data()?;
 
-        let claims: Claims = JANE_DOE_TOKEN.verify_with_store(&key_store)?;
+        let claims: Claims = JANE_DOE_SECOND_KEY_TOKEN.verify_with_store(&key_store)?;
 
         assert_eq!(claims.name, "Jane Doe");
+        Ok(())
+    }
+
+    #[test]
+    pub fn verify_claims_with_missing_key() -> Result<(), Error> {
+        let key_store: BTreeMap<_, _> = create_test_data()?;
+        let missing_key_token = "eyJhbGciOiJIUzUxMiIsImtpZCI6Im1pc3Npbmdfa2V5In0.eyJuYW1lIjoiSmFuZSBEb2UifQ.MC9hmBjv9OABdv5bsjVdwUgPOhvpe6a924KU-U7PjVWF2N-f_HXa1PVWtDVJ-dqt1GKutVwixrz7hgVvE_G5_w";
+
+        let should_fail_claims: Result<Claims, _> = missing_key_token.verify_with_store(&key_store);
+
+        match should_fail_claims {
+            Err(Error::NoKeyWithKeyId(key_id)) => assert_eq!(key_id, "missing_key"),
+            _ => panic!(
+                "Missing key should have triggered specific error but returned {:?}",
+                should_fail_claims
+            ),
+        }
+
         Ok(())
     }
 }

--- a/src/token/verified.rs
+++ b/src/token/verified.rs
@@ -146,7 +146,7 @@ pub(crate) fn split_components(token: &str) -> Result<[&str; 3], Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use hmac::{Hmac, NewMac};
     use serde::Deserialize;
@@ -225,8 +225,24 @@ mod tests {
     }
 
     #[test]
-    pub fn verify_claims_with_store() -> Result<(), Error> {
+    pub fn verify_claims_with_b_tree_map() -> Result<(), Error> {
         let mut key_store = BTreeMap::new();
+        let key1: Hmac<Sha256> = Hmac::new_varkey(b"first")?;
+        let key2: Hmac<Sha512> = Hmac::new_varkey(b"second")?;
+        key_store.insert("first_key", Box::new(key1) as Box<dyn VerifyingAlgorithm>);
+        key_store.insert("second_key", Box::new(key2) as Box<dyn VerifyingAlgorithm>);
+
+        let claims: Claims =
+        "eyJhbGciOiJIUzUxMiIsImtpZCI6InNlY29uZF9rZXkifQ.eyJuYW1lIjoiSmFuZSBEb2UifQ.t2ON5s8DDb2hefBIWAe0jaEcp-T7b2Wevmj0kKJ8BFxKNQURHpdh4IA-wbmBmqtiCnqTGoRdqK45hhW0AOtz0A"
+            .verify_with_store(&key_store)?;
+
+        assert_eq!(claims.name, "Jane Doe");
+        Ok(())
+    }
+
+    #[test]
+    pub fn verify_claims_with_hash_map() -> Result<(), Error> {
+        let mut key_store = HashMap::new();
         let key1: Hmac<Sha256> = Hmac::new_varkey(b"first")?;
         let key2: Hmac<Sha512> = Hmac::new_varkey(b"second")?;
         key_store.insert("first_key", Box::new(key1) as Box<dyn VerifyingAlgorithm>);

--- a/src/token/verified.rs
+++ b/src/token/verified.rs
@@ -147,6 +147,7 @@ pub(crate) fn split_components(token: &str) -> Result<[&str; 3], Error> {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
+    use std::iter::FromIterator;
 
     use hmac::{Hmac, NewMac};
     use serde::Deserialize;
@@ -224,17 +225,35 @@ mod tests {
         }
     }
 
-    #[test]
-    pub fn verify_claims_with_b_tree_map() -> Result<(), Error> {
-        let mut key_store = BTreeMap::new();
+    // Test stores
+
+    fn create_test_data<T>() -> Result<T, Error>
+    where
+        T: FromIterator<(&'static str, Box<dyn VerifyingAlgorithm>)>,
+    {
+        // Test two different algorithms in the same store
         let key1: Hmac<Sha256> = Hmac::new_varkey(b"first")?;
         let key2: Hmac<Sha512> = Hmac::new_varkey(b"second")?;
-        key_store.insert("first_key", Box::new(key1) as Box<dyn VerifyingAlgorithm>);
-        key_store.insert("second_key", Box::new(key2) as Box<dyn VerifyingAlgorithm>);
 
-        let claims: Claims =
-        "eyJhbGciOiJIUzUxMiIsImtpZCI6InNlY29uZF9rZXkifQ.eyJuYW1lIjoiSmFuZSBEb2UifQ.t2ON5s8DDb2hefBIWAe0jaEcp-T7b2Wevmj0kKJ8BFxKNQURHpdh4IA-wbmBmqtiCnqTGoRdqK45hhW0AOtz0A"
-            .verify_with_store(&key_store)?;
+        let name_to_key_tuples = vec![
+            ("first_key", Box::new(key1) as Box<dyn VerifyingAlgorithm>),
+            ("second_key", Box::new(key2) as Box<dyn VerifyingAlgorithm>),
+        ]
+        .into_iter()
+        .collect();
+
+        Ok(name_to_key_tuples)
+    }
+
+    // Header   {"alg":"HS512","kid":"second_key"}
+    // Claims   {"name":"Jane Doe"}
+    const JANE_DOE_TOKEN: &'static str = "eyJhbGciOiJIUzUxMiIsImtpZCI6InNlY29uZF9rZXkifQ.eyJuYW1lIjoiSmFuZSBEb2UifQ.t2ON5s8DDb2hefBIWAe0jaEcp-T7b2Wevmj0kKJ8BFxKNQURHpdh4IA-wbmBmqtiCnqTGoRdqK45hhW0AOtz0A";
+
+    #[test]
+    pub fn verify_claims_with_b_tree_map() -> Result<(), Error> {
+        let key_store: BTreeMap<_, _> = create_test_data()?;
+
+        let claims: Claims = JANE_DOE_TOKEN.verify_with_store(&key_store)?;
 
         assert_eq!(claims.name, "Jane Doe");
         Ok(())
@@ -242,15 +261,9 @@ mod tests {
 
     #[test]
     pub fn verify_claims_with_hash_map() -> Result<(), Error> {
-        let mut key_store = HashMap::new();
-        let key1: Hmac<Sha256> = Hmac::new_varkey(b"first")?;
-        let key2: Hmac<Sha512> = Hmac::new_varkey(b"second")?;
-        key_store.insert("first_key", Box::new(key1) as Box<dyn VerifyingAlgorithm>);
-        key_store.insert("second_key", Box::new(key2) as Box<dyn VerifyingAlgorithm>);
+        let key_store: HashMap<_, _> = create_test_data()?;
 
-        let claims: Claims =
-        "eyJhbGciOiJIUzUxMiIsImtpZCI6InNlY29uZF9rZXkifQ.eyJuYW1lIjoiSmFuZSBEb2UifQ.t2ON5s8DDb2hefBIWAe0jaEcp-T7b2Wevmj0kKJ8BFxKNQURHpdh4IA-wbmBmqtiCnqTGoRdqK45hhW0AOtz0A"
-            .verify_with_store(&key_store)?;
+        let claims: Claims = JANE_DOE_TOKEN.verify_with_store(&key_store)?;
 
         assert_eq!(claims.name, "Jane Doe");
         Ok(())


### PR DESCRIPTION
Fixes #61 

Breaking Changes:
* Users of data structures that are not BTreeMap and HashMap must implement the `Store` trait themselves. At least until impl specialization is possible.

* Use specific implementations of Store for BTreeMap and HashMap instead of Index, since Index does not support a checked get operation
* Add test HashMap
* Add test for missing key