### PR TITLE
Release 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwt"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Michael Yang <mikkyangg@gmail.com>"]
 description = "JSON Web Token library"
 documentation = "https://docs.rs/jwt"


### PR DESCRIPTION
Breaking Changes:

* Auto-implementation of `Store` for `Index` has been removed. BTreeMap and HashMap have specific implementations and there is no need for a change, but other types will need to implement `Store`.