### PR TITLE
Update base64, mac, hmac crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2018"
 features = ["openssl"]
 
 [dependencies]
-base64 = "0.12"
-crypto-mac = "0.9"
+base64 = "0.13"
+crypto-mac = "0.10"
 digest = "0.9"
-hmac = "0.9"
+hmac = "0.10"
 sha2 = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Just bumping the version numbers seems to work fine in my tests