### PR TITLE
Remove notes about legacy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@
 
 A JSON Web Token library.
 
-## Usage
-
-Note, for legacy support (not recommended, only supported up until 0.9.0), import from `jwt::legacy` instead
-of directly from `jwt`. Everything should work as before, with some small
-improvements.
-
 ### Only Claims
 
 If you don't care about that header as long as the header is verified, signing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-//! Note, for legacy support (not recommended), import from
-//! [`jwt::legacy`](legacy/index.html) instead of directly from `jwt`.
-//! Everything should work as before, with some small improvements.
 //! ### Only Claims
 //! If you don't care about that header as long as the header is verified, signing
 //! and verification can be done with just a few traits.


### PR DESCRIPTION
Seems they have been inapplicable for a year so probably fair game to
remove.
