### PR TITLE
header: implement Clone for Header

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -28,7 +28,7 @@ pub trait JoseHeader {
 
 /// Generic [JWT header](https://tools.ietf.org/html/rfc7519#page-11) with
 /// defined fields for common fields.
-#[derive(Default, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Header {
     #[serde(rename = "alg")]
     pub algorithm: AlgorithmType,


### PR DESCRIPTION
This trait is missing for no apparent reason from this type, so implement it to avoid users implement their own depending on the struct's fields.